### PR TITLE
Update default city and add debug endpoint for environment variables

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 *.log
 .DS_Store
 
+.vercel
+.env*.local

--- a/backend/server.js
+++ b/backend/server.js
@@ -41,6 +41,29 @@ app.get('/test/weather/:city', async (req, res) => {
   }
 });
 
+// Debug endpoint to check environment variables (without exposing values)
+app.get('/test/env', (req, res) => {
+  const envCheck = {
+    OPENWEATHER_API_KEY: !!process.env.OPENWEATHER_API_KEY,
+    WHATSAPP_API_TOKEN: !!process.env.WHATSAPP_API_TOKEN,
+    WHATSAPP_PHONE_NUMBER_ID: !!process.env.WHATSAPP_PHONE_NUMBER_ID,
+    WEBHOOK_VERIFY_TOKEN: !!process.env.WEBHOOK_VERIFY_TOKEN,
+    NODE_ENV: process.env.NODE_ENV
+  };
+
+  const allConfigured = Object.entries(envCheck)
+    .filter(([key]) => key !== 'NODE_ENV')
+    .every(([, value]) => value === true);
+
+  res.json({
+    configured: envCheck,
+    allSet: allConfigured,
+    message: allConfigured
+      ? 'All environment variables are configured ✅'
+      : 'Some environment variables are missing ❌'
+  });
+});
+
 // Error handling middleware
 app.use((err, req, res, next) => {
   console.error('Server error:', err);

--- a/backend/test-setup.js
+++ b/backend/test-setup.js
@@ -35,7 +35,7 @@ console.log('🌤️  Testing Weather Service...\n');
 
 const { fetchWeather } = require('./services/weatherService');
 
-fetchWeather('Nellore')
+fetchWeather('Delhi')
   .then(data => {
     console.log('✅ Weather API is working!');
     console.log(`   City: ${data.city}, ${data.country}`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ function App() {
 
   useEffect(() => {
     // Fetch weather for a default city on load
-    fetchWeather("Nellore");
+    fetchWeather("Delhi");
   }, []);
 
   const fetchWeather = async (city: string) => {


### PR DESCRIPTION
Change the default city for weather fetching to Delhi and introduce a debug endpoint to verify the configuration of essential environment variables without exposing their values.